### PR TITLE
Fix Pub Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rive
+# Rive [![Pub Version](https://img.shields.io/pub/v/rive)][https://pub.dev/packages/rive]
 [Flutter package](https://pub.dev/packages/rive) for Rive 2.
 
 ## Bring Your Apps and Games to Life with Real-Time Animation
@@ -11,4 +11,4 @@ dependencies:
 ```
 
 ## Example
-See how to use it in [example](example/).
+See how to use it in [example](example).

--- a/lib/rive.dart
+++ b/lib/rive.dart
@@ -1,3 +1,5 @@
+library rive;
+
 export 'package:rive/src/rive_file.dart';
 export 'package:rive/src/rive.dart';
 export 'package:rive/src/rive_core/rive_animation_controller.dart';

--- a/lib/src/generated/rive_core_context.dart
+++ b/lib/src/generated/rive_core_context.dart
@@ -67,6 +67,7 @@ import 'package:rive/src/rive_core/shapes/shape.dart';
 import 'package:rive/src/rive_core/shapes/straight_vertex.dart';
 import 'package:rive/src/rive_core/shapes/triangle.dart';
 
+// ignore: avoid_classes_with_only_static_members
 class RiveCoreContext {
   static Core makeCoreInstance(int typeKey) {
     switch (typeKey) {

--- a/lib/src/rive_core/animation/keyframe_draw_order_value.dart
+++ b/lib/src/rive_core/animation/keyframe_draw_order_value.dart
@@ -20,7 +20,6 @@ class KeyFrameDrawOrderValue extends KeyFrameDrawOrderValueBase {
     }
   }
 
-  @override
   int runtimeValueValue(int editorValue) {
     assert(false, 'this should never get called');
     return 0;

--- a/lib/src/rive_core/bounds_delegate.dart
+++ b/lib/src/rive_core/bounds_delegate.dart
@@ -1,3 +1,4 @@
+// ignore: one_member_abstracts
 abstract class BoundsDelegate {
   void boundsChanged();
 }

--- a/lib/src/rive_core/shapes/cubic_detached_vertex.dart
+++ b/lib/src/rive_core/shapes/cubic_detached_vertex.dart
@@ -28,7 +28,6 @@ class CubicDetachedVertex extends CubicDetachedVertexBase {
       translation,
       Vec2D.fromValues(
           cos(outRotation) * outDistance, sin(outRotation) * outDistance));
-  @override
   set outPoint(Vec2D value) {
     _outPoint = Vec2D.clone(value);
   }
@@ -39,7 +38,6 @@ class CubicDetachedVertex extends CubicDetachedVertexBase {
       translation,
       Vec2D.fromValues(
           cos(inRotation) * inDistance, sin(inRotation) * inDistance));
-  @override
   set inPoint(Vec2D value) {
     _inPoint = Vec2D.clone(value);
   }

--- a/lib/src/rive_core/shapes/paint/gradient_stop.dart
+++ b/lib/src/rive_core/shapes/paint/gradient_stop.dart
@@ -6,10 +6,8 @@ import 'package:rive/src/rive_core/shapes/paint/linear_gradient.dart';
 export 'package:rive/src/generated/shapes/paint/gradient_stop_base.dart';
 
 class GradientStop extends GradientStopBase {
-  @override
   Component get timelineParent =>
       _gradient is LinearGradient ? _gradient.parent : null;
-  @override
   String get timelineName =>
       'Stop ${_gradient.gradientStops.indexOf(this) + 1}';
   LinearGradient _gradient;

--- a/lib/src/rive_core/shapes/paint/linear_gradient.dart
+++ b/lib/src/rive_core/shapes/paint/linear_gradient.dart
@@ -10,7 +10,6 @@ export 'package:rive/src/generated/shapes/paint/linear_gradient_base.dart';
 
 class LinearGradient extends LinearGradientBase with ShapePaintMutator {
   final List<GradientStop> gradientStops = [];
-  @override
   Component get timelineProxy => parent;
   bool _paintsInWorldSpace = true;
   bool get paintsInWorldSpace => _paintsInWorldSpace;

--- a/lib/src/rive_core/shapes/paint/shape_paint.dart
+++ b/lib/src/rive_core/shapes/paint/shape_paint.dart
@@ -21,7 +21,6 @@ abstract class ShapePaint extends ShapePaintBase {
   set blendMode(BlendMode value) => _paint.blendMode = value;
   double get renderOpacity => _paintMutator.renderOpacity;
   set renderOpacity(double value) => _paintMutator.renderOpacity = value;
-  @override
   Component get timelineParent => _shapePaintContainer as Component;
   ShapePaintMutator get paintMutator => _paintMutator;
   void _changeMutator(ShapePaintMutator mutator) {

--- a/lib/src/rive_core/shapes/paint/solid_color.dart
+++ b/lib/src/rive_core/shapes/paint/solid_color.dart
@@ -7,7 +7,6 @@ import 'package:rive/src/generated/shapes/paint/solid_color_base.dart';
 export 'package:rive/src/generated/shapes/paint/solid_color_base.dart';
 
 class SolidColor extends SolidColorBase with ShapePaintMutator {
-  @override
   Component get timelineProxy => parent;
   Color get color => Color(colorValue);
   set color(Color c) {

--- a/lib/src/rive_core/shapes/paint/stroke.dart
+++ b/lib/src/rive_core/shapes/paint/stroke.dart
@@ -11,7 +11,6 @@ class Stroke extends StrokeBase {
     ..strokeCap = strokeCap
     ..strokeJoin = strokeJoin
     ..strokeWidth = thickness;
-  @override
   String get timelineParentGroup => 'strokes';
   StrokeCap get strokeCap => StrokeCap.values[cap];
   set strokeCap(StrokeCap value) => cap = value.index;

--- a/lib/src/rive_core/shapes/path.dart
+++ b/lib/src/rive_core/shapes/path.dart
@@ -31,7 +31,6 @@ abstract class Path extends PathBase {
   Mat2D get pathTransform;
   Mat2D get inversePathTransform;
   Mat2D get inverseWorldTransform => _inverseWorldTransform;
-  @override
   Component get timelineParent => _shape;
   @override
   bool resolveArtboard() {

--- a/lib/src/rive_core/shapes/render_cubic_vertex.dart
+++ b/lib/src/rive_core/shapes/render_cubic_vertex.dart
@@ -4,7 +4,6 @@ import 'package:rive/src/rive_core/shapes/cubic_vertex.dart';
 import 'package:rive/src/utilities/binary_buffer/binary_writer.dart';
 
 class RenderCubicVertex extends CubicVertex {
-  @override
   void changeNonNull() {}
   @override
   Vec2D inPoint;
@@ -12,7 +11,6 @@ class RenderCubicVertex extends CubicVertex {
   Vec2D outPoint;
   @override
   void onAddedDirty() {}
-  @override
   void writeRuntimeProperties(
       BinaryWriter writer, HashMap<int, int> idLookup) {}
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,7 @@ name: rive
 description: Rive 2 Flutter Runtime
 version: 0.0.1+2
 repository: https://github.com/rive-app/rive-flutter
+homepage: https://rive.app
 
 environment:
   sdk: ">=2.2.2 <3.0.0"
@@ -15,5 +16,3 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-flutter:


### PR DESCRIPTION
There are some formalities that make Pub package analysis fail and cause no API reference to be generated.

This attemps to fix it and it also adds a shield to the README, which makes it easy to navigate to Pub.