### PR TITLE
Add default noop implementations in RiveAnimationController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.6.2+1] - 2020-11-?? ??:??:??
+
+- Added default noop implementation to `onActivate`, `onDeactivate`, and `dispose`
+  in `RiveAnimationController`, which removes the need for noop overrides in subclasses
+  like `SimpleAnimation`.
+
 ## [0.6.2] - 2020-10-02 15:45:10
 
 - Exposed major and minor runtime version (issue #15) via riveVersion.

--- a/lib/src/controllers/simple_controller.dart
+++ b/lib/src/controllers/simple_controller.dart
@@ -34,13 +34,4 @@ class SimpleAnimation extends RiveAnimationController<RuntimeArtboard> {
       isActive = false;
     }
   }
-
-  @override
-  void dispose() {}
-
-  @override
-  void onActivate() {}
-
-  @override
-  void onDeactivate() {}
 }

--- a/lib/src/rive_core/rive_animation_controller.dart
+++ b/lib/src/rive_core/rive_animation_controller.dart
@@ -17,10 +17,10 @@ abstract class RiveAnimationController<T> {
   }
 
   @protected
-  void onActivate();
+  void onActivate() {}
   @protected
-  void onDeactivate();
+  void onDeactivate() {}
   void apply(T core, double elapsedSeconds);
   bool init(T core) => true;
-  void dispose();
+  void dispose() {}
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rive
 description: Rive 2 Flutter Runtime. This package provides runtime functionality for playing back and interacting with animations built with the Rive editor available at https://rive.app.
-version: 0.6.2
+version: 0.6.2+1
 repository: https://github.com/rive-app/rive-flutter
 homepage: https://rive.app
 


### PR DESCRIPTION
I think that `SimpleAnimation` shows that `onActivate`, `onDeactivate`, and `dispose` do not need to be implemented by `RiveAnimationController` subclasses necessarily.

This is why I would add a default noop implementation, which means that `SimpleAnimation` and other subclasses do not need to add a noop _override_s.

Our implementation also does:

```dart
  @override
  void dispose() {}

  @override
  void onActivate() {}

  @override
  void onDeactivate() {}
```

This is obviously not a big deal - I just noticed it.