### PR TITLE
Fix minor version reading newer minor version.

### DIFF
--- a/lib/src/rive_file.dart
+++ b/lib/src/rive_file.dart
@@ -153,8 +153,11 @@ class RiveFile {
 
       assert(!artboard.children.contains(artboard),
           'artboard should never contain itself as a child');
-      for (final object in artboard.objects) {
-        object?.onAdded();
+      for (final object in artboard.objects.toList(growable:false)) {
+        if(object == null) {
+          continue;
+        }
+        object.onAdded();
       }
       artboard.clean();
     }
@@ -165,7 +168,8 @@ class RiveFile {
 
 void _skipProperty(BinaryReader reader, int propertyKey,
     HashMap<int, CoreFieldType> propertyToField) {
-  var field = propertyToField[propertyKey];
+  var field =
+      RiveCoreContext.coreType(propertyKey) ?? propertyToField[propertyKey];
   if (field == null) {
     throw UnsupportedError('Unsupported property key $propertyKey. '
         'A new runtime is likely necessary to play this file.');

--- a/lib/src/runtime_artboard.dart
+++ b/lib/src/runtime_artboard.dart
@@ -18,8 +18,10 @@ class RuntimeArtboard extends Artboard implements CoreContext {
 
   @override
   T addObject<T extends Core>(T object) {
-    object.context = this;
-    object.id = _objects.length;
+    if (object != null) {
+      object.context = this;
+      object.id = _objects.length;
+    }
     _objects.add(object);
     return object;
   }


### PR DESCRIPTION
Some newer minor versions could include entirely new objects. We need to make sure we skip reading known properties from unknown objects. So we first look for the coreType from core (which contains known properties) before reading it from the TOC (containing potentially unknown properties).