### PR TITLE
Support for intrinsic size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.6.7] - 2021-01-23 11:11:02
+
+- Adds support for Rive.useIntrinsicSize to allow Rive widgets to be self sized by their artboard. Set useIntrinsicSize to false when you want the widget to try to occupy the entire space provided by the parent.
+
 ## [0.6.6+1] - 2021-01-18 17:06:17
 
 - Fixes a crashing issue introduced in 0.6.6.

--- a/lib/src/rive.dart
+++ b/lib/src/rive.dart
@@ -24,6 +24,8 @@ class Rive extends LeafRenderObjectWidget {
       ..artboard = artboard
       ..fit = fit
       ..alignment = alignment
+      ..intrinsicSize =
+          artboard == null ? Size.zero : Size(artboard.width, artboard.height)
       ..useIntrinsicSize = useIntrinsicSize;
   }
 
@@ -34,6 +36,8 @@ class Rive extends LeafRenderObjectWidget {
       ..artboard = artboard
       ..fit = fit
       ..alignment = alignment
+      ..intrinsicSize =
+          artboard == null ? Size.zero : Size(artboard.width, artboard.height)
       ..useIntrinsicSize = useIntrinsicSize;
   }
 

--- a/lib/src/rive_render_box.dart
+++ b/lib/src/rive_render_box.dart
@@ -12,6 +12,12 @@ abstract class RiveRenderBox extends RenderBox {
   Alignment _alignment;
   bool _useIntrinsicSize = false;
 
+  @override
+  Size computeDryLayout(BoxConstraints constraints) {
+    return constraints
+        .constrainSizeAndAttemptToPreserveAspectRatio(_intrinsicSize);
+  }
+
   bool get useIntrinsicSize => _useIntrinsicSize;
   set useIntrinsicSize(bool value) {
     if (_useIntrinsicSize == value) {
@@ -66,7 +72,10 @@ abstract class RiveRenderBox extends RenderBox {
 
   @override
   void performResize() {
-    size = _useIntrinsicSize ? constraints.smallest : constraints.biggest;
+    if (_useIntrinsicSize) {
+      super.performResize();
+    }
+    size = constraints.biggest;
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rive
 description: Rive 2 Flutter Runtime. This package provides runtime functionality for playing back and interacting with animations built with the Rive editor available at https://rive.app.
-version: 0.6.6+1
+version: 0.6.7
 repository: https://github.com/rive-app/rive-flutter
 homepage: https://rive.app
 


### PR DESCRIPTION
Adds support for using the artboard size as the intrinsic size of the widget. Set Rive.useIntrinsicSize to true to allow the widget to size itself (note that parent constraints will also be taken into account).