### PR TITLE
Implement intrinsic sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.6.8] - 2021-02-12 11:11:11
+
+- Adds support for Flutter's `getMinIntrinsicWidth` (max, height, etc.), e.g. for `IntrinsicWidth`
+  and `IntrinsicHeight` usage.
+- Renames `Rive.useIntrinsicSize` to `Rive.useArtboardSize` by deprecating the former. The
+  motivation for this is avoiding ambiguity with Flutter's intrinsics contract.
+
 ## [0.6.7] - 2021-01-23 11:11:02
 
 - Adds support for Rive.useIntrinsicSize to allow Rive widgets to be self sized by their artboard. Set useIntrinsicSize to false when you want the widget to try to occupy the entire space provided by the parent.

--- a/lib/src/rive.dart
+++ b/lib/src/rive.dart
@@ -7,16 +7,40 @@ import 'package:rive/src/runtime_artboard.dart';
 
 class Rive extends LeafRenderObjectWidget {
   final Artboard artboard;
-  final bool useIntrinsicSize;
+
+  /// Determines whether to use the inherent size of the [artboard], i.e. the
+  /// absolute size defined by the artboard, or size the widget based on the
+  /// available constraints only (sized by parent).
+  ///
+  /// Defaults to `false`, i.e. defaults to sizing based on the available
+  /// constraints instead of the artboard size.
+  ///
+  /// When `true`, the artboard size is constrained by the parent constraints.
+  /// Using the artboard size has the benefit that the widget now has an
+  /// *intrinsic* size.
+  ///
+  /// When `false`, the intrinsic size is `(0, 0)` because
+  /// there is no size intrinsically - it only comes from the parent
+  /// constraints. Consequently, if you intend to use the widget in the subtree
+  /// of an [IntrinsicWidth] or [IntrinsicHeight] widget or intend to directly
+  /// obtain the [RenderBox.getMinIntrinsicWidth] et al., you will want to set
+  /// this to `true`.
+  final bool useArtboardSize;
+
   final BoxFit fit;
   final Alignment alignment;
 
   const Rive({
-    @required this.artboard,
-    this.useIntrinsicSize = false,
+    @required
+        this.artboard,
+    @Deprecated("Replaced by [useArtboardSize] in order to avoid confusion "
+        "with Flutter's intrinsics contract.")
+        bool useIntrinsicSize,
+    bool useArtboardSize = false,
     this.fit = BoxFit.contain,
     this.alignment = Alignment.center,
-  });
+  })  : assert(useArtboardSize != null),
+        useArtboardSize = useIntrinsicSize ?? useArtboardSize;
 
   @override
   RenderObject createRenderObject(BuildContext context) {
@@ -24,9 +48,9 @@ class Rive extends LeafRenderObjectWidget {
       ..artboard = artboard
       ..fit = fit
       ..alignment = alignment
-      ..intrinsicSize =
+      ..artboardSize =
           artboard == null ? Size.zero : Size(artboard.width, artboard.height)
-      ..useIntrinsicSize = useIntrinsicSize;
+      ..useArtboardSize = useArtboardSize;
   }
 
   @override
@@ -36,9 +60,9 @@ class Rive extends LeafRenderObjectWidget {
       ..artboard = artboard
       ..fit = fit
       ..alignment = alignment
-      ..intrinsicSize =
+      ..artboardSize =
           artboard == null ? Size.zero : Size(artboard.width, artboard.height)
-      ..useIntrinsicSize = useIntrinsicSize;
+      ..useArtboardSize = useArtboardSize;
   }
 
   @override
@@ -49,7 +73,9 @@ class Rive extends LeafRenderObjectWidget {
 
 class RiveRenderObject extends RiveRenderBox {
   RuntimeArtboard _artboard;
+
   RuntimeArtboard get artboard => _artboard;
+
   set artboard(Artboard value) {
     if (_artboard == value) {
       return;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rive
 description: Rive 2 Flutter Runtime. This package provides runtime functionality for playing back and interacting with animations built with the Rive editor available at https://rive.app.
-version: 0.6.7
+version: 0.6.8
 repository: https://github.com/rive-app/rive-flutter
 homepage: https://rive.app
 


### PR DESCRIPTION
## Description

Fixes #53 and resolves #54.
@luigi-rosso I am not strong on anything in this PR - open to suggestions! :)

I implemented this to my best judgement, which is also why I removed the ambiguity of `useIntrinsicSize`, however, I do not have any strong feelings about it.  

### Notes

I tried to [explain Flutter's intrinsics here](https://youtu.be/HqXNGawzSbY?t=4345), however, I just briefly touched it. The docs on the `RenderBox` methods explain it very well, so you might want to read that if you want to understand how it works.

In this case, I adapted the approach from `RenderImage` mostly, just to follow framework conventions in some way.

## Results

@luigi-rosso Because I imagine you are curious, this is how it helps us:

### Before

![image](https://user-images.githubusercontent.com/19204050/107815151-e15f1d00-6d6a-11eb-90c7-9270c2829748.png)

(disclaimer: the content of it is just a joke 😂)

### After

<img width="442" alt="Screen Shot 2021-02-12 at 19 46 26" src="https://user-images.githubusercontent.com/19204050/107815234-ffc51880-6d6a-11eb-8c87-372c2c0e6150.png">


---

The reason this did not work **before** is because we use intrinsic sizing for our table (which you can see in the screenshot) in order to judge the cell size distribution :)