### PR TITLE
Migrate package to null safety

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  graphs: ^0.2.0
-  meta: ^1.2.3
+  graphs: ^1.0.0
+  meta: ^1.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
First of all thanks so much for creating this package.

I, just like many others are eager to see a null safe version of it, I lack the skills for actually modifying the code and migrating it to null safety, but since I haven't seen a null safety PR yet, I thought I'd update the dependencies and open one for others to help and contribute to,

This is what I've done:

- run `dart pub outdated --mode=null-safety`
- run `dart pub upgrade --null-safety` 