### PR TITLE
Update example_animation.dart

### DIFF
--- a/example/lib/example_animation.dart
+++ b/example/lib/example_animation.dart
@@ -40,6 +40,8 @@ class _ExampleAnimationState extends State<ExampleAnimation> {
         // Add a controller to play back a known animation on the main/default
         // artboard. We store a reference to it so we can toggle playback.
         artboard.addController(_controller = SimpleAnimation('idle'));
+        // starts animation in paused state rateher than looping to match example  intention
+        _controller!.isActive = false;
         setState(() => _riveArtboard = artboard);
       },
     );


### PR DESCRIPTION
my first rive contribution 

start this example in paused state so not only does the playback button match the state of animation but then corrects starts the animation