### PR TITLE
Package not compatible with runtime flutter-web on Web

### DIFF
--- a/lib/src/widgets/rive_animation.dart
+++ b/lib/src/widgets/rive_animation.dart
@@ -1,10 +1,10 @@
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:rive/rive.dart';
 import 'package:rive/src/rive_core/artboard.dart';
+import 'package:universal_io/io.dart';
 
 enum _Source {
   asset,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
     sdk: flutter
   graphs: ^2.0.0
   meta: ^1.3.0
+  universal_io: ^2.0.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
People are confused with however this runtime can be used to build for web. On the pub.dev page there is no chip for Web:
![image](https://user-images.githubusercontent.com/495782/120826303-9146d900-c55a-11eb-96f1-ae7d92e06f7d.png)
![image](https://user-images.githubusercontent.com/495782/120826353-a02d8b80-c55a-11eb-9d57-263ff213f91b.png)

- Use package universal_io instead of dart:io to solve pub.dev "Package not compatible with runtime flutter-web on Web"