### PR TITLE
Adds flag for resetOnStop

### DIFF
--- a/lib/src/controllers/one_shot_controller.dart
+++ b/lib/src/controllers/one_shot_controller.dart
@@ -5,6 +5,9 @@ import 'package:rive/src/controllers/simple_controller.dart';
 
 /// Controller tailered for managing one-shot animations
 class OneShotAnimation extends SimpleAnimation {
+  /// Prevents animation from resetting when animation stops being active
+  final bool resetOnStop;
+  
   /// Fires when the animation stops being active
   final VoidCallback? onStop;
 
@@ -15,6 +18,7 @@ class OneShotAnimation extends SimpleAnimation {
     String animationName, {
     double mix = 1,
     bool autoplay = true,
+    this.resetOnStop = true,
     this.onStop,
     this.onStart,
   }) : super(animationName, mix: mix, autoplay: autoplay) {
@@ -32,7 +36,7 @@ class OneShotAnimation extends SimpleAnimation {
   void onActiveChanged() {
     // If the animation stops and it is at the end of the one-shot, reset the
     // animation back to the starting time
-    if (!isActive) {
+    if (!isActive && resetOnStop) {
       reset();
     }
     // Fire any callbacks


### PR DESCRIPTION
This flag will allow you to prevent the animation from resetting when the animation is complete.  This is useful because it allows you to use the OneShotAnimation Controller to create a splash screen and to be able to tie into the onStop callback to close the splash screen or toggle a flag letting you know that the splash screen has completed, and that you can dismiss the splash screen when your data has finished loading.