### PR TITLE
Remove unnecessary null checks, which result in compiler warnings

### DIFF
--- a/lib/src/controllers/one_shot_controller.dart
+++ b/lib/src/controllers/one_shot_controller.dart
@@ -37,6 +37,6 @@ class OneShotAnimation extends SimpleAnimation {
     isActive
         ? onStart?.call()
         // onStop can fire while widgets are still drawing
-        : WidgetsBinding.instance?.addPostFrameCallback((_) => onStop?.call());
+        : WidgetsBinding.instance.addPostFrameCallback((_) => onStop?.call());
   }
 }

--- a/lib/src/rive_core/state_machine_controller.dart
+++ b/lib/src/rive_core/state_machine_controller.dart
@@ -218,7 +218,7 @@ class StateMachineController extends RiveAnimationController<CoreContext> {
 
   /// Handles state change callbacks
   void _onStateChange(LayerState layerState) =>
-      SchedulerBinding.instance?.addPostFrameCallback((_) {
+      SchedulerBinding.instance.addPostFrameCallback((_) {
         String stateName = 'unknown';
         if (layerState is AnimationState && layerState.animation != null) {
           stateName = layerState.animation!.name;

--- a/lib/src/rive_render_box.dart
+++ b/lib/src/rive_render_box.dart
@@ -187,7 +187,7 @@ abstract class RiveRenderBox extends RenderBox {
       return;
     }
     _frameCallbackId =
-        SchedulerBinding.instance?.scheduleFrameCallback(_frameCallback) ?? -1;
+        SchedulerBinding.instance.scheduleFrameCallback(_frameCallback);
   }
 
   /// Override this if you want to do custom viewTransform alignment. This will


### PR DESCRIPTION
According to the Dart flow analysis, these 3 null-checks are not needed. Removing them got rid of these compiler warnings:

```: Warning: Operand of null-aware operation '?.' has type 'WidgetsBinding' which excludes null.
../…/controllers/one_shot_controller.dart:40
- 'WidgetsBinding' is from 'package:flutter[/src/widgets/binding.dart]()' ('.[./../bin/flutter/packages/flutter/lib/src/widgets/binding.dart]()').
package:flutter/…/widgets/binding.dart:1
        : WidgetsBinding.instance?.addPostFrameCallback((_) => onStop?.call());
                         ^

: Warning: Operand of null-aware operation '?.' has type 'SchedulerBinding' which excludes null.
../…/rive_core/state_machine_controller.dart:221
- 'SchedulerBinding' is from 'package:flutter[/src/scheduler/binding.dart]()' ('.[./../bin/flutter/packages/flutter/lib/src/scheduler/binding.dart]()').
package:flutter/…/scheduler/binding.dart:1
      SchedulerBinding.instance?.addPostFrameCallback((_) {
                       ^
: Warning: Operand of null-aware operation '?.' has type 'SchedulerBinding' which excludes null.
../…/src/rive_render_box.dart:190
- 'SchedulerBinding' is from 'package:flutter[/src/scheduler/binding.dart]()' ('.[./../bin/flutter/packages/flutter/lib/src/scheduler/binding.dart]()').
package:flutter/…/scheduler/binding.dart:1
        SchedulerBinding.instance?.scheduleFrameCallback(_frameCallback) ?? -1;```