### PR TITLE
Remove deprecated reference to `io.flutter.app.FlutterApplication`

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,12 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.rive_example">
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
-         In most cases you can leave this as-is, but you if you want to provide
-         additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
         android:label="rive_example"
         android:icon="@mipmap/ic_launcher">
         <activity


### PR DESCRIPTION
Android V1 embedding is deprecated and slated for deletion. This line can be removed.