### PR TITLE
Fix publish workflow to prevent accidental publishes

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   merge_job:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
So that closed PR's to master don't accidentally get published if it doesn't merge