### PR TITLE
Consider artboard origin when computed artboard local coord.

### DIFF
--- a/lib/src/rive_core/state_machine_controller.dart
+++ b/lib/src/rive_core/state_machine_controller.dart
@@ -250,8 +250,10 @@ class StateMachineController extends RiveAnimationController<CoreContext> {
   late List<_HitShape> hitShapes;
   late List<NestedArtboard> hitNestedArtboards;
 
+  Artboard? _artboard;
+
   /// The artboard that this state machine controller is manipulating.
-  Artboard? get artboard => stateMachine.artboard;
+  Artboard? get artboard => _artboard;
 
   @override
   bool init(CoreContext core) {
@@ -292,12 +294,14 @@ class StateMachineController extends RiveAnimationController<CoreContext> {
     }
     hitShapes = hitShapeLookup.values.toList();
 
-    var artboard = core as RuntimeArtboard;
+    _artboard = core as RuntimeArtboard;
 
     List<NestedArtboard> nestedArtboards = [];
-    for (final nestedArtboard in artboard.activeNestedArtboards) {
-      if (nestedArtboard.hasNestedStateMachine) {
-        nestedArtboards.add(nestedArtboard);
+    if (_artboard != null) {
+      for (final nestedArtboard in _artboard!.activeNestedArtboards) {
+        if (nestedArtboard.hasNestedStateMachine) {
+          nestedArtboards.add(nestedArtboard);
+        }
       }
     }
     hitNestedArtboards = nestedArtboards;
@@ -338,6 +342,18 @@ class StateMachineController extends RiveAnimationController<CoreContext> {
   }
 
   void _processEvent(Vec2D position, {EventType? hitEvent}) {
+    var artboard = this.artboard;
+    if (artboard == null) {
+      return;
+    }
+    if (artboard.frameOrigin) {
+      // ignore: parameter_assignments
+      position = position -
+          Vec2D.fromValues(
+            artboard.width * artboard.originX,
+            artboard.height * artboard.originY,
+          );
+    }
     const hitRadius = 2;
     var hitArea = IAABB(
       (position.x - hitRadius).round(),

--- a/lib/src/runtime_nested_artboard.dart
+++ b/lib/src/runtime_nested_artboard.dart
@@ -129,6 +129,7 @@ class RuntimeNestedStateMachineInstance extends NestedStateMachineInstance {
 class RuntimeMountedArtboard extends MountedArtboard {
   final RuntimeArtboard artboardInstance;
   RuntimeMountedArtboard(this.artboardInstance) {
+    artboardInstance.frameOrigin = false;
     artboardInstance.advance(0, nested: true);
   }
 
@@ -142,8 +143,6 @@ class RuntimeMountedArtboard extends MountedArtboard {
   void draw(Canvas canvas) {
     canvas.save();
     canvas.transform(worldTransform.mat4);
-    canvas.translate(-artboardInstance.originX * artboardInstance.width,
-        -artboardInstance.originY * artboardInstance.height);
     artboardInstance.draw(canvas);
     canvas.restore();
   }
@@ -169,10 +168,4 @@ class RuntimeMountedArtboard extends MountedArtboard {
   @override
   bool advance(double seconds) =>
       artboardInstance.advance(seconds, nested: true);
-
-  @override
-  Mat2D get originTransform => Mat2D.fromTranslate(
-        artboardInstance.width * -artboardInstance.originX,
-        artboardInstance.height * -artboardInstance.originY,
-      );
 }

--- a/lib/src/widgets/rive_animation.dart
+++ b/lib/src/widgets/rive_animation.dart
@@ -189,7 +189,11 @@ class _RiveAnimationState extends State<RiveAnimation> {
     }
     var globalCoordinates = renderObject.localToGlobal(local);
 
-    return riveRenderer!.globalToArtboard(globalCoordinates);
+    var artboardCoord = riveRenderer!.globalToArtboard(globalCoordinates);
+
+    return artboardCoord -
+        Vec2D.fromValues(_artboard!.originX * _artboard!.width,
+            _artboard!.originY * _artboard!.height);
   }
 
   Widget _optionalHitTester(BuildContext context, Widget child) {

--- a/lib/src/widgets/rive_animation.dart
+++ b/lib/src/widgets/rive_animation.dart
@@ -189,18 +189,17 @@ class _RiveAnimationState extends State<RiveAnimation> {
     }
     var globalCoordinates = renderObject.localToGlobal(local);
 
-    var artboardCoord = riveRenderer!.globalToArtboard(globalCoordinates);
-
-    return artboardCoord -
-        Vec2D.fromValues(_artboard!.originX * _artboard!.width,
-            _artboard!.originY * _artboard!.height);
+    return riveRenderer!.globalToArtboard(globalCoordinates);
   }
 
   Widget _optionalHitTester(BuildContext context, Widget child) {
     assert(_artboard != null);
-    var hasHitTesting = _artboard!.animationControllers.any((controller) =>
-        controller is StateMachineController &&
-        controller.hitShapes.isNotEmpty);
+    var hasHitTesting = _artboard!.animationControllers.any(
+      (controller) =>
+          controller is StateMachineController &&
+          (controller.hitShapes.isNotEmpty ||
+              controller.hitNestedArtboards.isNotEmpty),
+    );
 
     if (hasHitTesting) {
       void hitHelper(PointerEvent event,


### PR DESCRIPTION
Same fix as applied to rive-cpp, note that here we call it before calling into pointerDown/Up/Move as this allows it work for NestedArtboards too.

https://github.com/rive-app/rive-cpp/pull/319