### PR TITLE
Fix Flutter 3 warnings while maintaining compatibility

### DIFF
--- a/lib/src/controllers/one_shot_controller.dart
+++ b/lib/src/controllers/one_shot_controller.dart
@@ -1,7 +1,15 @@
 import 'package:flutter/widgets.dart';
 import 'package:rive/src/controllers/simple_controller.dart';
 
-/// Controller tailered for managing one-shot animations
+/// This allows a value of type T or T?
+/// to be treated as a value of type T?.
+///
+/// We use this so that APIs that have become
+/// non-nullable can still be used with `!` and `?`
+/// to support older versions of the API as well.
+T? _ambiguate<T>(T? value) => value;
+
+/// Controller tailored for managing one-shot animations
 class OneShotAnimation extends SimpleAnimation {
   /// Fires when the animation stops being active
   final VoidCallback? onStop;
@@ -37,6 +45,7 @@ class OneShotAnimation extends SimpleAnimation {
     isActive
         ? onStart?.call()
         // onStop can fire while widgets are still drawing
-        : WidgetsBinding.instance?.addPostFrameCallback((_) => onStop?.call());
+        : _ambiguate(WidgetsBinding.instance)
+            ?.addPostFrameCallback((_) => onStop?.call());
   }
 }

--- a/lib/src/rive_core/state_machine_controller.dart
+++ b/lib/src/rive_core/state_machine_controller.dart
@@ -22,7 +22,7 @@ import 'package:rive/src/rive_core/node.dart';
 import 'package:rive/src/rive_core/rive_animation_controller.dart';
 import 'package:rive/src/rive_core/shapes/shape.dart';
 
-/// Callback signature for satate machine state changes
+/// Callback signature for state machine state changes
 typedef OnStateChange = void Function(String, String);
 
 /// Callback signature for layer state changes
@@ -206,6 +206,14 @@ class LayerController {
   }
 }
 
+/// This allows a value of type T or T?
+/// to be treated as a value of type T?.
+///
+/// We use this so that APIs that have become
+/// non-nullable can still be used with `!` and `?`
+/// to support older versions of the API as well.
+T? _ambiguate<T>(T? value) => value;
+
 class StateMachineController extends RiveAnimationController<CoreContext> {
   final StateMachine stateMachine;
   final _inputValues = HashMap<int, dynamic>();
@@ -226,7 +234,7 @@ class StateMachineController extends RiveAnimationController<CoreContext> {
 
   /// Handles state change callbacks
   void _onStateChange(LayerState layerState) =>
-      SchedulerBinding.instance?.addPostFrameCallback((_) {
+      _ambiguate(SchedulerBinding.instance)?.addPostFrameCallback((_) {
         String stateName = 'unknown';
         if (layerState is AnimationState && layerState.animation != null) {
           stateName = layerState.animation!.name;

--- a/lib/src/rive_render_box.dart
+++ b/lib/src/rive_render_box.dart
@@ -7,6 +7,14 @@ import 'package:rive/src/rive_core/math/aabb.dart';
 import 'package:rive/src/rive_core/math/mat2d.dart';
 import 'package:rive/src/rive_core/math/vec2d.dart';
 
+/// This allows a value of type T or T?
+/// to be treated as a value of type T?.
+///
+/// We use this so that APIs that have become
+/// non-nullable can still be used with `!` and `?`
+/// to support older versions of the API as well.
+T? _ambiguate<T>(T? value) => value;
+
 abstract class RiveRenderBox extends RenderBox {
   final Stopwatch _stopwatch = Stopwatch();
   BoxFit _fit = BoxFit.none;
@@ -186,8 +194,9 @@ abstract class RiveRenderBox extends RenderBox {
     if (_frameCallbackId != -1) {
       return;
     }
-    _frameCallbackId =
-        SchedulerBinding.instance?.scheduleFrameCallback(_frameCallback) ?? -1;
+    _frameCallbackId = _ambiguate(SchedulerBinding.instance)
+            ?.scheduleFrameCallback(_frameCallback) ??
+        -1;
   }
 
   /// Override this if you want to do custom viewTransform alignment. This will


### PR DESCRIPTION
This fixes the same warnings in Flutter 3 as #222 and #224 while using the recommended method to maintain backward compatibility: https://docs.flutter.dev/development/tools/sdk/release-notes/release-notes-3.0.0#your-code