### PR TITLE
Use the stopwatch from the clock package

### DIFF
--- a/lib/src/rive_render_box.dart
+++ b/lib/src/rive_render_box.dart
@@ -1,5 +1,7 @@
 import 'dart:math';
 
+import 'package:clock/clock.dart';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
@@ -16,7 +18,7 @@ import 'package:rive/src/rive_core/math/vec2d.dart';
 T? _ambiguate<T>(T? value) => value;
 
 abstract class RiveRenderBox extends RenderBox {
-  final Stopwatch _stopwatch = Stopwatch();
+  final Stopwatch _stopwatch = clock.stopwatch();
   BoxFit _fit = BoxFit.none;
   Alignment _alignment = Alignment.center;
   bool _useArtboardSize = false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
+  clock: ^1.1.0
   collection: ^1.15.0
   flutter:
     sdk: flutter


### PR DESCRIPTION
This makes rive animations respect fake clocks during testing.

We use rive in our app and tested that this did not introduce any visual change in the app. It does fix timeouts in our tests though.

We use flutters [`pumpAndSettle`](https://api.flutter.dev/flutter/flutter_test/WidgetTester/pumpAndSettle.html) in our tests, which started throwing timeout errors when we were switching from flare to rive. The flutter testing framework uses a fake clock (from the [clock package](https://pub.dev/packages/clock)). `pumpAndSettle` has a timeout of `10` minutes, but this refers to the fake clock, which advances much faster during the test, so the timeout is hit and our rive animations are still running because less than a second might have passed in real time.