### PR TITLE
Allow initialising a Rive Animation providing the RiveFile & setting t…

### DIFF
--- a/example/lib/carousel.dart
+++ b/example/lib/carousel.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:rive/rive.dart';
+
+/// An example showing how to drive a StateMachine via one numeric input.
+class AnimationCarousel extends StatefulWidget {
+  const AnimationCarousel({Key? key}) : super(key: key);
+
+  @override
+  _AnimationCarouselState createState() => _AnimationCarouselState();
+}
+
+class _AnimationCarouselState extends State<AnimationCarousel> {
+  final riveFiles = [
+    'assets/liquid_download.riv',
+    'assets/little_machine.riv',
+    'assets/off_road_car.riv',
+    'assets/rocket.riv',
+    'assets/skills.riv',
+    // not a pretty out of the box example
+    'assets/light_switch.riv',
+    // v6.0 file,
+    // 'assets/teeny_tiny.riv',
+  ];
+
+  var _index = 0;
+  void next() {
+    setState(() {
+      _index += 1;
+    });
+  }
+
+  void previous() {
+    setState(() {
+      _index -= 1;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey,
+      appBar: AppBar(
+        title: const Text('Animation Carousel'),
+      ),
+      body: Center(
+          child: Row(children: [
+        GestureDetector(
+            onTap: previous,
+            child: const Icon(
+              Icons.arrow_back,
+            )),
+        Expanded(
+            child: RiveAnimation.asset(
+          riveFiles[_index % riveFiles.length],
+        )),
+        GestureDetector(
+            onTap: next,
+            child: const Icon(
+              Icons.arrow_forward,
+            )),
+      ])),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:rive_example/simple_animation.dart';
 import 'package:rive_example/simple_machine_listener.dart';
 import 'package:rive_example/simple_state_machine.dart';
 import 'package:rive_example/state_machine_skills.dart';
+import 'package:rive_example/carousel.dart';
 
 void main() => runApp(MaterialApp(
       title: 'Navigation Basics',
@@ -159,6 +160,20 @@ class Home extends StatelessWidget {
                   context,
                   MaterialPageRoute<void>(
                     builder: (context) => const StateMachineListener(),
+                  ),
+                );
+              },
+            ),
+            const SizedBox(
+              height: 10,
+            ),
+            ElevatedButton(
+              child: const Text('Animation Carousel'),
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute<void>(
+                    builder: (context) => const AnimationCarousel(),
                   ),
                 );
               },

--- a/lib/src/widgets/rive_animation.dart
+++ b/lib/src/widgets/rive_animation.dart
@@ -7,7 +7,7 @@ enum _Source {
   asset,
   network,
   file,
-  riveFile,
+  direct,
 }
 
 /// The callback signature for onInit
@@ -103,7 +103,7 @@ class RiveAnimation extends StatefulWidget {
         src = _Source.file,
         super(key: key);
 
-  const RiveAnimation.riveFile(
+  const RiveAnimation.direct(
     this.file, {
     this.artboard,
     this.animations = const [],
@@ -116,14 +116,15 @@ class RiveAnimation extends StatefulWidget {
     this.onInit,
     Key? key,
   })  : name = null,
-        src = _Source.riveFile,
+        src = _Source.direct,
         super(key: key);
 
   @override
-  _RiveAnimationState createState() => _RiveAnimationState();
+  RiveAnimationState createState() => RiveAnimationState();
 }
 
-class _RiveAnimationState extends State<RiveAnimation> {
+@visibleForTesting
+class RiveAnimationState extends State<RiveAnimation> {
   /// Rive controller
   final _controllers = <RiveAnimationController>[];
 
@@ -143,7 +144,7 @@ class _RiveAnimationState extends State<RiveAnimation> {
       RiveFile.network(widget.name!).then(_init);
     } else if (widget.src == _Source.file) {
       RiveFile.file(widget.name!).then(_init);
-    } else if (widget.src == _Source.riveFile) {
+    } else if (widget.src == _Source.direct) {
       _init(widget.file!);
     }
   }

--- a/lib/src/widgets/rive_animation.dart
+++ b/lib/src/widgets/rive_animation.dart
@@ -7,6 +7,7 @@ enum _Source {
   asset,
   network,
   file,
+  riveFile,
 }
 
 /// The callback signature for onInit
@@ -17,7 +18,10 @@ typedef OnInitCallback = void Function(Artboard);
 /// within it are used.
 class RiveAnimation extends StatefulWidget {
   /// The asset name or url
-  final String name;
+  final String? name;
+
+  /// The Rive File object
+  final RiveFile? file;
 
   /// The type of source used to retrieve the asset
   final _Source src;
@@ -62,7 +66,10 @@ class RiveAnimation extends StatefulWidget {
     this.antialiasing = true,
     this.controllers = const [],
     this.onInit,
-  }) : src = _Source.asset;
+    Key? key,
+  })  : file = null,
+        src = _Source.asset,
+        super(key: key);
 
   const RiveAnimation.network(
     this.name, {
@@ -75,7 +82,10 @@ class RiveAnimation extends StatefulWidget {
     this.antialiasing = true,
     this.controllers = const [],
     this.onInit,
-  }) : src = _Source.network;
+    Key? key,
+  })  : file = null,
+        src = _Source.network,
+        super(key: key);
 
   const RiveAnimation.file(
     this.name, {
@@ -88,7 +98,26 @@ class RiveAnimation extends StatefulWidget {
     this.antialiasing = true,
     this.controllers = const [],
     this.onInit,
-  }) : src = _Source.file;
+    Key? key,
+  })  : file = null,
+        src = _Source.file,
+        super(key: key);
+
+  const RiveAnimation.riveFile(
+    this.file, {
+    this.artboard,
+    this.animations = const [],
+    this.stateMachines = const [],
+    this.fit,
+    this.alignment,
+    this.placeHolder,
+    this.antialiasing = true,
+    this.controllers = const [],
+    this.onInit,
+    Key? key,
+  })  : name = null,
+        src = _Source.riveFile,
+        super(key: key);
 
   @override
   _RiveAnimationState createState() => _RiveAnimationState();
@@ -104,14 +133,38 @@ class _RiveAnimationState extends State<RiveAnimation> {
   @override
   void initState() {
     super.initState();
+    _configure();
+  }
 
+  void _configure() {
     if (widget.src == _Source.asset) {
-      RiveFile.asset(widget.name).then(_init);
+      RiveFile.asset(widget.name!).then(_init);
     } else if (widget.src == _Source.network) {
-      RiveFile.network(widget.name).then(_init);
+      RiveFile.network(widget.name!).then(_init);
     } else if (widget.src == _Source.file) {
-      RiveFile.file(widget.name).then(_init);
+      RiveFile.file(widget.name!).then(_init);
+    } else if (widget.src == _Source.riveFile) {
+      _init(widget.file!);
     }
+  }
+
+  @override
+  void didUpdateWidget(covariant RiveAnimation oldWidget) {
+    if (widget.alignment != oldWidget.alignment ||
+        widget.animations != oldWidget.animations ||
+        widget.antialiasing != oldWidget.antialiasing ||
+        widget.artboard != oldWidget.artboard ||
+        widget.controllers != oldWidget.controllers ||
+        widget.file != oldWidget.file ||
+        widget.fit != oldWidget.fit ||
+        widget.name != oldWidget.name ||
+        widget.onInit != oldWidget.onInit ||
+        widget.placeHolder != oldWidget.placeHolder ||
+        widget.src != oldWidget.src ||
+        widget.stateMachines != oldWidget.stateMachines) {
+      setState(_configure);
+    }
+    super.didUpdateWidget(oldWidget);
   }
 
   /// Initializes the artboard, animations, state machines and controllers
@@ -156,7 +209,7 @@ class _RiveAnimationState extends State<RiveAnimation> {
       }
     });
 
-    // Add any user-created contollers
+    // Add any user-created controllers
     widget.controllers.forEach(artboard.addController);
 
     setState(() => _artboard = artboard);

--- a/test/rive_animation_test.dart
+++ b/test/rive_animation_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rive/rive.dart';
+import 'src/utils.dart';
+
+class TestApp extends StatefulWidget {
+  final RiveFile file;
+  const TestApp(this.file) : super();
+
+  @override
+  _TestAppState createState() => _TestAppState();
+}
+
+class _TestAppState extends State<TestApp> {
+  int _counter = 0;
+  String animation = "";
+  final animations = ["one", "two"];
+
+  @override
+  void initState() {
+    animation = animations.first;
+  }
+
+  void _changeAnimation() {
+    setState(() {
+      _counter += 1;
+      animation = animations[_counter % animations.length];
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: RiveAnimation.direct(
+          widget.file,
+          animations: [animation],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(onPressed: _changeAnimation),
+    );
+  }
+}
+
+void main() {
+  testWidgets('Render a rive file', (WidgetTester tester) async {
+    // Build our app and trigger a frame.
+    final riveBytes = loadFile('assets/rive-flutter-test-asset.riv');
+    final riveFile = RiveFile.import(riveBytes);
+    await tester.pumpWidget(MaterialApp(home: RiveAnimation.direct(riveFile)));
+  });
+
+  testWidgets('Changing animation changes rive widget',
+      (WidgetTester tester) async {
+    // Build our app and trigger a frame.
+    final riveBytes = loadFile('assets/rive-flutter-test-asset.riv');
+    final riveFile = RiveFile.import(riveBytes);
+
+    await tester.pumpWidget(MaterialApp(home: TestApp(riveFile)));
+
+    final initialState =
+        tester.state(find.byType(RiveAnimation).first) as RiveAnimationState;
+    expect(initialState.widget.animations, ["one"]);
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+    final finalState =
+        tester.state(find.byType(RiveAnimation).first) as RiveAnimationState;
+    expect(finalState.widget.animations, ["two"]);
+  });
+}


### PR DESCRIPTION
…he Key

Looking @ using our flutter runtime to show previews in the editor. There is currently no way to initialise a RiveAnimation from a RiveFile directly. 

We also do not have Keys on our StatefulWidget, adding this allows us to force a re render of the RiveAnimation when changing animation, but maybe there is a better way to do this? 

Todo: 
- [ ] add tests, want to verify we want this behaviour before going down this path


Relates to https://github.com/rive-app/rive/issues/4135