### PR TITLE
refactor: renamed example

### DIFF
--- a/example/lib/simple_state_machine.dart
+++ b/example/lib/simple_state_machine.dart
@@ -23,7 +23,7 @@ class _SimpleStateMachineState extends State<SimpleStateMachine> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Simple Animation'),
+        title: const Text('Simple State Machine'),
       ),
       body: Center(
         child: GestureDetector(


### PR DESCRIPTION
### Description
As a developer I would like to have the example AppBar to be renamed accordingly. I think this is a typo.