### PR TITLE
[Draft] Prevent scrolling when interacting with listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.2
+
+- Prevents scroll views from scrolling when dragging listeners. 
+
 ## 0.9.1
 
 - Support for Nested Inputs.

--- a/lib/src/rive_core/animation/nested_state_machine.dart
+++ b/lib/src/rive_core/animation/nested_state_machine.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:rive/src/core/core.dart';
 import 'package:rive/src/generated/animation/nested_state_machine_base.dart';
 import 'package:rive/src/rive_core/math/vec2d.dart';
@@ -14,7 +15,7 @@ abstract class NestedStateMachineInstance {
 
   void pointerMove(Vec2D position);
 
-  void pointerDown(Vec2D position);
+  void pointerDown(Vec2D position, PointerDownEvent event);
 
   void pointerUp(Vec2D position);
 
@@ -57,8 +58,8 @@ class NestedStateMachine extends NestedStateMachineBase {
   void pointerMove(Vec2D position) =>
       _stateMachineInstance?.pointerMove(position);
 
-  void pointerDown(Vec2D position) =>
-      _stateMachineInstance?.pointerDown(position);
+  void pointerDown(Vec2D position, PointerDownEvent event) =>
+      _stateMachineInstance?.pointerDown(position, event);
 
   void pointerUp(Vec2D position) => _stateMachineInstance?.pointerUp(position);
 

--- a/lib/src/rive_core/state_machine_controller.dart
+++ b/lib/src/rive_core/state_machine_controller.dart
@@ -317,6 +317,7 @@ class StateMachineController extends RiveAnimationController<CoreContext> {
   @override
   void dispose() {
     _clearLayerControllers();
+    _recognizer.dispose();
     super.dispose();
   }
 

--- a/lib/src/rive_core/state_machine_controller.dart
+++ b/lib/src/rive_core/state_machine_controller.dart
@@ -393,8 +393,10 @@ class StateMachineController extends RiveAnimationController<CoreContext> {
         // user-selectable value in the inspector?
 
         // Just use bounds for now
-        foundTarget = true;
         isOver = hitTester.test();
+        if (isOver) {
+          foundTarget = true;
+        }
       }
 
       bool hoverChange = hitShape.isHovered != isOver;

--- a/lib/src/runtime_nested_artboard.dart
+++ b/lib/src/runtime_nested_artboard.dart
@@ -113,8 +113,8 @@ class RuntimeNestedStateMachineInstance extends NestedStateMachineInstance {
       stateMachineController.isActiveChanged;
 
   @override
-  void pointerDown(Vec2D position) =>
-      stateMachineController.pointerDown(position);
+  void pointerDown(Vec2D position, PointerDownEvent event) =>
+      stateMachineController.pointerDown(position, event);
 
   @override
   void pointerMove(Vec2D position) =>

--- a/lib/src/widgets/rive_animation.dart
+++ b/lib/src/widgets/rive_animation.dart
@@ -272,7 +272,7 @@ class RiveAnimationState extends State<RiveAnimation> {
         onPointerDown: (details) => hitHelper(
           details,
           (controller, artboardPosition) =>
-              controller.pointerDown(artboardPosition),
+              controller.pointerDown(artboardPosition, details),
         ),
         onPointerUp: (details) => hitHelper(
           details,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rive
 description: Rive 2 Flutter Runtime. This package provides runtime functionality for playing back and interacting with animations built with the Rive editor available at https://rive.app.
-version: 0.9.1
+version: 0.9.2
 repository: https://github.com/rive-app/rive-flutter
 homepage: https://rive.app
 


### PR DESCRIPTION
Draft PR for preventing parent scrollviews of a `Rive` widget to scroll when interacting with listeners.

By introducing an `ImmediateMultiDragGestureRecognizer ` for every `StateMachineController` and adding events to it if the event actually targets a `HitShape`, we can take part in the flutter gesture arena and follow the flutter gesture protocol (at least for drag gestures).

This means users can still scroll on the parts of a rive that are not interactive.