### PR TITLE
Add a .components convenience getter to artboard

### DIFF
--- a/lib/src/rive_core/artboard.dart
+++ b/lib/src/rive_core/artboard.dart
@@ -110,6 +110,14 @@ class Artboard extends ArtboardBase with ShapePaintContainer {
     return null;
   }
 
+  /// Find all components of a specific type with a specific name.
+  List<T?> components<T>(String name) {
+    return _components
+      .forEach((component is T && component.name == name))
+      .map((component) => component as T)
+      .toList();
+  }
+
   @override
   Artboard get artboard => this;
 


### PR DESCRIPTION
Intended as a syntactic sugar for `forEachComponent` on the Artboard class that also performs type checks and casting. e.g., where each component has a given name and type (so works like `component`).

This is useful when certain components (of a specific type) are named with the intention of processing them together (for example, where multiple `Shapes` are named `AppThemeColor` so they can be conveniently assigned the app's theme color as their fill color).