### PR TITLE
use asset bundle of inherited widget instead of root

### DIFF
--- a/lib/src/rive_file.dart
+++ b/lib/src/rive_file.dart
@@ -293,11 +293,9 @@ class RiveFile {
     FileAssetLoader? assetLoader,
     bool cdn = true,
     bool importEmbeddedAssets = true,
-    AssetBundle? bundle,
+    required AssetBundle bundle,
   }) async {
-    final bytes = await (bundle ?? rootBundle).load(
-      bundleKey,
-    );
+    final bytes = await bundle.load(bundleKey);
 
     return RiveFile.import(
       bytes,

--- a/lib/src/widgets/rive_animation.dart
+++ b/lib/src/widgets/rive_animation.dart
@@ -190,6 +190,7 @@ class RiveAnimationState extends State<RiveAnimation> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _configure());
     _configure();
   }
 
@@ -208,6 +209,7 @@ class RiveAnimationState extends State<RiveAnimation> {
           widget.name!,
           importEmbeddedAssets: widget.importEmbeddedAssets!,
           assetLoader: widget.assetLoader,
+          bundle: DefaultAssetBundle.of(context),
         );
       case _Source.network:
         return RiveFile.network(


### PR DESCRIPTION
One should never use rootBundle because it cannot be overridden for example during testing. It's better to use DefaultAssetBundle.of(context).