### PR TITLE
FEATURE: Choose whether to reset or not a OneShotAnimation

### DIFF
--- a/lib/src/controllers/one_shot_controller.dart
+++ b/lib/src/controllers/one_shot_controller.dart
@@ -17,10 +17,14 @@ class OneShotAnimation extends SimpleAnimation {
   /// Fires when the animation starts being active
   final VoidCallback? onStart;
 
+  /// If false the animation won't be reset to its starting frame
+  final bool resetOnEnd;
+
   OneShotAnimation(
     String animationName, {
     double mix = 1,
     bool autoplay = true,
+    this.resetOnEnd = true,
     this.onStop,
     this.onStart,
   }) : super(animationName, mix: mix, autoplay: autoplay) {
@@ -38,7 +42,7 @@ class OneShotAnimation extends SimpleAnimation {
   void onActiveChanged() {
     // If the animation stops and it is at the end of the one-shot, reset the
     // animation back to the starting time
-    if (!isActive) {
+    if (!isActive && resetOnEnd) {
       reset();
     }
     // Fire any callbacks


### PR DESCRIPTION
Currently a OneShotAnimation resets the animation to its first frame at his hand. This PR introduces the possibility to disable this behavior.