### PR TITLE
Broken URLs in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## 0.12.4
 
-- Adds `behavior` argument to `RiveAnimation` and `Rive`. An enum `RiveHitTestBehavior` specifies how to handle hit testing on an animation. Default is `RiveHitTestBehavior.opaque` - comsuming all hit events for the artboard bounds.
+- Adds `behavior` argument to `RiveAnimation` and `Rive`. An enum `RiveHitTestBehavior` specifies how to handle hit testing on an animation. Default is `RiveHitTestBehavior.opaque` - consuming all hit events for the artboard bounds.
 - Collapsed nested artboards don't listen to pointer events anymore
 - Constraints pointing to collapsed targets are not applied
 
@@ -142,7 +142,7 @@ Deprecated:
 
 ## 0.10.1
 
-- Fix [[277](https://github.com/rive-app/rive-flutter/issues/277)] and [[278](https://github.com/rive-app/rive-flutter/issues/278)] that resuled in `onInit` being called with each `setState` - thank you [xuelongqy](https://github.com/xuelongqy).
+- Fix [[277](https://github.com/rive-app/rive-flutter/issues/277)] and [[278](https://github.com/rive-app/rive-flutter/issues/278)] that resulted in `onInit` being called with each `setState` - thank you [xuelongqy](https://github.com/xuelongqy).
 
 ## 0.10.0
 
@@ -238,7 +238,7 @@ Fix for setState being called while mounted in RiveAnimation. [`#172`](https://g
 
 - Adds ability to pass controllers into RiveAnimation widgets
 - Adds autoplay option to SimpleAnimation controller
-- Adds one-shot animation contoller
+- Adds one-shot animation controller
 - Updates examples
 
 ## 0.7.17 - (2021-06-11)

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ This library allows you to fully control Rive files with a high-level API for si
 
 ## Table of contents
 
-- :star: [Rive Overview](#rive-overview)
+- :star: [Rive Overview](#overview-of-rive)
 - 🚀 [Getting Started & API docs](#getting-started)
 - :mag: [Supported Platforms](#supported-platforms)
-- :books: [Examples](#examples)
+- :books: [Examples](#awesome-rive)
 - 👨‍💻 [Contributing](#contributing)
 - :question: [Issues](#issues)
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ For more information, check out the following resources:
 ## Getting started
 
 To get started with Rive Flutter, check out the following resources:
-- [Getting Started with Rive in Flutter](https://help.rive.app/runtimes/overview/flutter)
 
+- [Getting Started with Rive in Flutter](https://help.rive.app/runtimes/overview/flutter)
 - [Alternative Widget Setup](https://help.rive.app/runtimes/overview/flutter/alternative-widget-setup)
 
 For additional help, see the Runtime sections of the Rive help documentation, such as:
+
 - [Animation Playback](https://help.rive.app/runtimes/playback)
 - [State Machines](https://help.rive.app/runtimes/state-machines)
 


### PR DESCRIPTION
This will fix: 

- the broken links in toc
- some mark down warnings
- and some typos.

Close #384 