### PR TITLE
Do not run the ticker when TickerMode is disabled

### DIFF
--- a/lib/src/rive_render_box.dart
+++ b/lib/src/rive_render_box.dart
@@ -203,7 +203,9 @@ abstract class RiveRenderBox extends RenderBox {
     super.attach(owner);
 
     _ticker = Ticker(_frameCallback);
-    _startTicker();
+    if (tickerModeEnabled) {
+      _startTicker();
+    }
   }
 
   void _stopTicker() {


### PR DESCRIPTION
We do not want to start the animation on `attach` when is explicitly disabled with a `TickerMode`.
