### PR TITLE
Allow component to be found based on a predicate

### DIFF
--- a/lib/src/rive_core/artboard.dart
+++ b/lib/src/rive_core/artboard.dart
@@ -115,8 +115,13 @@ class Artboard extends ArtboardBase with ShapePaintContainer {
 
   /// Find a component of a specific type with a specific name.
   T? component<T>(String name) {
+    return getComponentWhereOrNull((component) => component.name == name);
+  }
+
+  /// Find a component that matches the given predicate.
+  T? getComponentWhereOrNull<T>(bool Function(Component) callback) {
     for (final component in _components) {
-      if (component is T && component.name == name) {
+      if (component is T && callback(component)) {
         return component as T;
       }
     }


### PR DESCRIPTION
Currently, there's no easy way to find a Component (or sub-type) from an Artboard that matches a predicate (e.g. component whose name starts with "shoulder:"). We may be able to use the existing `forEachComponent` function and find a component that matches a predicate externally, but that has no way to return early once it finds a matching component.

This addition exposes a new API that allows users to find components that match a predicate more efficiently.

Thank you.