### PR TITLE
Expose speedMultiplier property

### DIFF
--- a/lib/src/rive.dart
+++ b/lib/src/rive.dart
@@ -94,6 +94,11 @@ class Rive extends LeafRenderObjectWidget {
   /// {@endtemplate}
   final Rect? clipRect;
 
+  /// A multiplier for controlling the speed of the Rive animation playback.
+  ///
+  /// Default `1.0`.
+  final double speedMultiplier;
+
   const Rive({
     required this.artboard,
     super.key,
@@ -105,6 +110,7 @@ class Rive extends LeafRenderObjectWidget {
     this.fit = BoxFit.contain,
     this.alignment = Alignment.center,
     this.clipRect,
+    this.speedMultiplier = 1.0,
   });
 
   @override
@@ -121,7 +127,8 @@ class Rive extends LeafRenderObjectWidget {
       ..tickerModeEnabled = tickerModeValue
       ..enableHitTests = enablePointerEvents
       ..cursor = cursor
-      ..behavior = behavior;
+      ..behavior = behavior
+      ..speedMultiplier = speedMultiplier;
   }
 
   @override
@@ -139,12 +146,14 @@ class Rive extends LeafRenderObjectWidget {
       ..tickerModeEnabled = tickerModeValue
       ..enableHitTests = enablePointerEvents
       ..cursor = cursor
-      ..behavior = behavior;
+      ..behavior = behavior
+      ..speedMultiplier = speedMultiplier;
   }
 }
 
 class RiveRenderObject extends RiveRenderBox implements MouseTrackerAnnotation {
   RuntimeArtboard _artboard;
+  double _speedMultiplier = 1;
   RiveRenderObject(
     this._artboard, {
     this.behavior = RiveHitTestBehavior.opaque,
@@ -165,6 +174,14 @@ class RiveRenderObject extends RiveRenderBox implements MouseTrackerAnnotation {
     _artboard = value as RuntimeArtboard;
     _artboard.redraw.addListener(scheduleRepaint);
     markNeedsLayout();
+  }
+
+  double get speedMultiplier => _speedMultiplier;
+
+  set speedMultiplier(double value) {
+    if (value != _speedMultiplier) {
+      _speedMultiplier = value;
+    }
   }
 
   /// Local offset to global artboard position
@@ -333,7 +350,8 @@ class RiveRenderObject extends RiveRenderBox implements MouseTrackerAnnotation {
 
   @override
   bool advance(double elapsedSeconds) =>
-      _artboard.isPlaying && _artboard.advance(elapsedSeconds, nested: true);
+      _artboard.isPlaying &&
+      _artboard.advance(elapsedSeconds * _speedMultiplier, nested: true);
 
   @override
   void beforeDraw(Canvas canvas, Offset offset) {

--- a/lib/src/widgets/rive_animation.dart
+++ b/lib/src/widgets/rive_animation.dart
@@ -71,6 +71,11 @@ class RiveAnimation extends StatefulWidget {
   /// rendering.
   final ObjectGenerator? objectGenerator;
 
+  /// A multiplier for controlling the speed of the Rive animation playback.
+  ///
+  /// Default `1.0`.
+  final double speedMultiplier;
+
   /// Creates a new [RiveAnimation] from an asset bundle.
   ///
   /// *Example:*
@@ -92,6 +97,7 @@ class RiveAnimation extends StatefulWidget {
     this.onInit,
     this.behavior = RiveHitTestBehavior.opaque,
     this.objectGenerator,
+    this.speedMultiplier = 1,
     Key? key,
   })  : name = asset,
         file = null,
@@ -121,6 +127,7 @@ class RiveAnimation extends StatefulWidget {
     this.headers,
     this.behavior = RiveHitTestBehavior.opaque,
     this.objectGenerator,
+    this.speedMultiplier = 1,
     Key? key,
   })  : name = url,
         file = null,
@@ -148,6 +155,7 @@ class RiveAnimation extends StatefulWidget {
     this.onInit,
     this.behavior = RiveHitTestBehavior.opaque,
     this.objectGenerator,
+    this.speedMultiplier = 1,
     Key? key,
   })  : name = path,
         file = null,
@@ -176,6 +184,7 @@ class RiveAnimation extends StatefulWidget {
     this.clipRect,
     this.controllers = const [],
     this.onInit,
+    this.speedMultiplier = 1,
     Key? key,
     this.behavior = RiveHitTestBehavior.opaque,
   })  : name = null,
@@ -346,6 +355,7 @@ class RiveAnimationState extends State<RiveAnimation> {
           clipRect: widget.clipRect,
           enablePointerEvents: _shouldAddHitTesting,
           behavior: widget.behavior,
+          speedMultiplier: widget.speedMultiplier,
         )
       : widget.placeHolder ?? const SizedBox();
 }


### PR DESCRIPTION
Currently, updating the playback speed requires creating a custom render object, which unfortunately restricts the use of existing `RiveAnimation` utilities, such as `RiveAnimation.asset`.

By exposing the `speedMultiplier` property, we provide a straightforward way to control playback speed without affecting the existing API, as its default value is `1.0`. This enhancement will greatly benefit users who wish to customize animation playback to suit their specific needs.