### PR TITLE
Avoid initializing AudioEngine instance when audio is absent in AudioEvent

### DIFF
--- a/lib/src/rive_core/state_machine_controller.dart
+++ b/lib/src/rive_core/state_machine_controller.dart
@@ -640,7 +640,7 @@ class StateMachineController extends RiveAnimationController<CoreContext>
       var riveEvents = <RiveEvent>[];
 
       for (final event in events) {
-        if (event is AudioEvent) {
+        if (event is AudioEvent && event.asset != null) {
           event.play(audioPlayer);
         }
         riveEvents.add(RiveEvent.fromCoreEvent(event));


### PR DESCRIPTION
**Issue**:
There is a frequent (but inconsistent) crash on Android devices with Android 10 (aka API 29) and below, caused when miniaudio disposes of its AudioEngine and attempts to free its audio buffers. This specific crash is really [a race condition issue with miniaudio on Android 10-](https://github.com/mackron/miniaudio/issues/833#issuecomment-2082527323), but Rive indirectly triggers this through `StateMachineController.dispose()`. This results in a full crash, i.e. app quits completely and unexpectedly.

<details>

<summary>More context on how this crash is triggered from Rive code...</summary>

When an `AudioEvent` is received in `StateMachineController.applyEvents()`, an instance of Rive's `AudioEngine` is created [through the `audioPlayer` getter](https://github.com/rive-app/rive-flutter/blob/master/lib/src/rive_core/state_machine_controller.dart#L644), which consequently also initializes a miniaudio player. Note that this getter is currently invoked and the `AudioEngine` is instantiated even if the `AudioEvent` lacks an audio asset.

While this is harmless on its own, in such cases where the `AudioEngine` is created, calling `StateMachineController.dispose()` later also attempts to dispose the miniaudio player, resulting in the Android crash referenced above.

</details>

<details>

<summary>The crash stack trace looks something like this...</summary>

```
E/libc++abi: Pure virtual function called!
F/libc: Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 24289 (AudioTrack), pid 24246 (ter_audio_crash)
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
backtrace:
#00  pc 0x00000000000705ac  /apex/com.android.runtime/lib64/bionic/libc.so (abort+160)
#01  pc 0x00000000000500fc  /system/lib64/libc++.so (abort_message+232)
#02  pc 0x0000000000065bf4  /system/lib64/libc++.so (__cxa_pure_virtual+16)
#03  pc 0x00000000000257ec  /system/lib64/libaaudio.so (aaudio::AudioStreamLegacy::processCallbackCommon(int, void*)+1112)
#04  pc 0x000000000006c3a8  /system/lib64/libaudioclient.so (android::AudioTrack::processAudioBuffer()+2628)
#05  pc 0x000000000006b65c  /system/lib64/libaudioclient.so (android::AudioTrack::AudioTrackThread::threadLoop()+264)
#06  pc 0x00000000000136c4  /system/lib64/libutils.so (android::Thread::_threadLoop(void*)+316)
#07  pc 0x00000000000e5e4c  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::javaThreadShell(void*)+140)
#08  pc 0x00000000000cf700  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+36)
#09  pc 0x00000000000720e8  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)
```

</details>

On a related note, this condition [also affects SoLoud](https://github.com/alnitak/flutter_soloud/issues/68), another Flutter package using miniaudio. SoLoud addresses it by switching to OpenSL for Android 10 and below.

---

**Solution:**
The perfect solution would be to fix the deref race conditions in miniaudio for Android 10.

But as a preventative measure in Rive, we can also avoid the crash circumstances for Rive users who don't use audio, by bypassing the miniaudio engine creation/disposal (through `StateMachineController.audioPlayer`) when audio is absent from an `AudioEvent`.

This change also provides a minor performance benefit by avoiding allocations through `AudioEngine.init()` if the file happens to send an empty `AudioEvent`. 

---

**Additional context:**
I ran the package tests in my local clone, but they fail. As I understand, this is to be expected for now because of the custom dylib depdendencies. I tried to use the [library generation script from this thread](https://github.com/rive-app/rive-flutter/issues/354#issuecomment-2084677570) but unfortunately couldn't fix the tests. I'm happy to try any alternative suggestions to help with checks.

Let me know if I missed anything please. Thanks for creating this useful runtime!
