### PR TITLE
feat(flutter): add `assetLoader` parameter and `.fromBytes` constructor to `FileLoader`

### DIFF
--- a/lib/src/file_loader.dart
+++ b/lib/src/file_loader.dart
@@ -1,7 +1,9 @@
 import 'dart:async' show Completer;
+import 'dart:typed_data';
 
 import 'package:rive/rive.dart' as rive;
 import 'package:rive/src/errors.dart';
+import 'package:rive_native/rive_native.dart' show AssetLoaderCallback;
 
 /// {@template FileLoader}
 /// A class that loads a Rive file from an asset, URL, or file.
@@ -18,29 +20,46 @@ class FileLoader {
   final rive.Factory riveFactory;
   final rive.File? _providedFile;
   final String? _asset;
+  final Uint8List? _bytes;
   final String? _url;
+  final AssetLoaderCallback? assetLoader;
+
   Completer<rive.File>? _loadCompleter;
   rive.File? _loadedFile;
 
   /// {@macro FileLoader}
   /// - The [asset] parameter is the asset to load the Rive file from.
-  FileLoader.fromAsset(String asset, {required this.riveFactory})
+  FileLoader.fromAsset(String asset,
+      {required this.riveFactory, this.assetLoader})
       : _asset = asset,
+        _bytes = null,
         _providedFile = null,
         _url = null;
 
   /// {@macro FileLoader}
   /// - The [url] parameter is the URL to load the Rive file from.
-  FileLoader.fromUrl(String url, {required this.riveFactory})
+  FileLoader.fromUrl(String url, {required this.riveFactory, this.assetLoader})
       : _url = url,
+        _asset = null,
+        _bytes = null,
+        _providedFile = null;
+
+  /// {@macro FileLoader}
+  /// - The [bytes] parameter is the bytes to load the Rive file from.
+  FileLoader.fromBytes(Uint8List bytes,
+      {required this.riveFactory, this.assetLoader})
+      : _bytes = bytes,
+        _asset = null,
         _providedFile = null,
-        _asset = null;
+        _url = null;
 
   /// {@macro FileLoader}
   /// - The [file] parameter is the file to load the Rive file from.
   FileLoader.fromFile(rive.File file, {required this.riveFactory})
-      : _providedFile = file,
+      : assetLoader = null,
+        _providedFile = file,
         _asset = null,
+        _bytes = null,
         _url = null;
 
   Future<rive.File> file() async {
@@ -60,7 +79,8 @@ class FileLoader {
 
       if (_asset != null) {
         try {
-          file = await rive.File.asset(_asset, riveFactory: riveFactory);
+          file = await rive.File.asset(_asset,
+              riveFactory: riveFactory, assetLoader: assetLoader);
         } catch (e) {
           // Handle the case where the asset doesn't exist or has empty data
           throw RiveFileLoaderException(
@@ -70,9 +90,23 @@ class FileLoader {
           throw RiveFileLoaderException(
               'Failed to decode Rive file from asset: $_asset');
         }
+      } else if (_bytes != null) {
+        try {
+          file = await rive.File.decode(_bytes,
+              riveFactory: riveFactory, assetLoader: assetLoader);
+        } catch (e) {
+          // Handle the case where the bytes are invalid or empty
+          throw RiveFileLoaderException(
+              'Failed to load Rive file from bytes. Error: $e');
+        }
+        if (file == null) {
+          throw RiveFileLoaderException(
+              'Failed to decode Rive file from bytes');
+        }
       } else if (_url != null) {
         try {
-          file = await rive.File.url(_url, riveFactory: riveFactory);
+          file = await rive.File.url(_url,
+              riveFactory: riveFactory, assetLoader: assetLoader);
         } catch (e) {
           // Handle the case where the URL fails to load
           throw RiveFileLoaderException(


### PR DESCRIPTION
### Description
This PR introduces the ability to load Rive files directly from a byte array (`Uint8List`) by adding a new `fromBytes` constructor to the `FileLoader` class. Additionally, it allows developers to pass an optional `AssetLoaderCallback` (as `assetLoader`) when loading files from an asset, URL, or directly from bytes, enabling more granular control over custom asset loading.

### Motivation and Context
Currently, `FileLoader` provides quick ways to load a Rive file via an asset or URL, but lacks a direct way to instantiate it natively from raw memory bytes. Furthermore, allowing the injection of an `AssetLoaderCallback` makes out-of-band assets (like images, fonts, or audio) easier to manage and resolve dynamically at runtime during the file loading stage.

### Changes made
*   **Added `FileLoader.fromBytes()`:** A new named constructor that takes a `Uint8List` corresponding to the Rive file's byte data.
*   **Added `assetLoader` parameter:** Included an optional `AssetLoaderCallback? assetLoader` parameter mapped to the `fromAsset`, `fromUrl`, and `fromBytes` constructors.
*   **Updated internal file decode routing:** 
    * Passed `assetLoader` downwards into `rive.File.asset`, `rive.File.url`, and `rive.File.decode`.
    * Implemented logic in the `file()` future method to decode `_bytes` with fallback `RiveFileLoaderException` error handling if the byte decoding fails.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update